### PR TITLE
Add dataset-select benchmark

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -31,6 +31,13 @@
     }
   },
   {
+    "command": "dataset-select ALL --iterations=3",
+    "flags": {
+      "cloud": true,
+      "language": "Python"
+    }
+  },
+  {
     "command": "file-read ALL --iterations=3 --all=true",
     "flags": {
       "language": "Python"

--- a/benchmarks/_sources.py
+++ b/benchmarks/_sources.py
@@ -108,6 +108,18 @@ STORE = {
         ],
         "region": "us-east-2",
     },
+    "nyctaxi_multi_parquet_s3_repartitioned": {
+        "download": False,
+        "paths": [
+            f"ursa-labs-taxi-data-repartitioned-10k/{year}/{month:02}/{part:04}/data.parquet"
+            for year in range(2009, 2020)
+            for month in range(1, 13)
+            for part in range(101)
+            if not (year == 2019 and month > 6)  # Data ends in 2019/06
+            and not (year == 2010 and month == 3)  # Data is missing in 2010/03
+        ],
+        "region": "us-east-2",
+    },
 }
 
 

--- a/benchmarks/dataset_select_benchmark.py
+++ b/benchmarks/dataset_select_benchmark.py
@@ -1,0 +1,68 @@
+import conbench.runner
+import pyarrow.dataset
+
+from benchmarks import _benchmark
+
+
+@conbench.runner.register_benchmark
+class DatasetSelectBenchmark(_benchmark.Benchmark):
+    """
+    Read and filter a dataset on partition expressions.
+
+        DatasetSelectBenchmark().run(<source>, options...)
+
+    Parameters
+    ----------
+    source : str
+        A source name from the benchmarks source store.
+    cpu_count : int, optional
+        Set the number of threads to use in parallel operations (arrow).
+    iterations : int, default 1
+        Number of times to run the benchmark.
+    gc_collect : boolean, default True
+        Whether to do garbage collection before each benchmark run.
+    gc_disable : boolean, default True
+        Whether to do disable collection during each benchmark run.
+    run_id : str, optional
+        Group executions together with a run id.
+
+    Returns
+    -------
+    (result, output) : sequence
+        result : The benchmark result.
+        output : The output from the benchmarked function.
+    """
+
+    name = "dataset-select"
+    arguments = ["source"]
+    sources = ["nyctaxi_multi_parquet_s3_repartitioned"]
+    # This does not load a large amount of data in tests because we always pluck exactly one file from the dataset
+    sources_test = ["nyctaxi_multi_parquet_s3_repartitioned"]
+    options = {"cpu_count": {"type": int}}
+    flags = {"cloud": True}
+
+    def run(self, source, cpu_count=None, **kwargs):
+        path_prefix = "ursa-labs-taxi-data-repartitioned-10k/"
+        partitioning = pyarrow.dataset.DirectoryPartitioning.discover(
+            field_names=["year", "month", "part"],
+            infer_dictionary=True,
+        )
+        for source in self.get_sources(source):
+            s3 = pyarrow.fs.S3FileSystem(region=source.region)
+            dataset = pyarrow.dataset.dataset(
+                source.paths,
+                format="parquet",
+                filesystem=s3,
+                partitioning=partitioning,
+                partition_base_dir=path_prefix,
+            )
+            f = self._get_benchmark_function(dataset)
+            tags = self.get_tags(source, cpu_count)
+            yield self.benchmark(f, tags, kwargs)
+
+    def _get_benchmark_function(self, dataset):
+        year = pyarrow.dataset.field("year")
+        month = pyarrow.dataset.field("month")
+        part = pyarrow.dataset.field("part")
+        filter_expr = (year == "2011") & (month == 1) & (part == 2)
+        return lambda: dataset.to_table(filter=filter_expr)

--- a/benchmarks/dataset_select_benchmark.py
+++ b/benchmarks/dataset_select_benchmark.py
@@ -36,7 +36,8 @@ class DatasetSelectBenchmark(_benchmark.Benchmark):
     name = "dataset-select"
     arguments = ["source"]
     sources = ["nyctaxi_multi_parquet_s3_repartitioned"]
-    # This does not load a large amount of data in tests because we always pluck exactly one file from the dataset
+    # This does not load a large amount of data in tests because we
+    # always pluck exactly one file from the dataset
     sources_test = ["nyctaxi_multi_parquet_s3_repartitioned"]
     options = {"cpu_count": {"type": int}}
     flags = {"cloud": True}

--- a/benchmarks/tests/test_dataset_select_benchmark.py
+++ b/benchmarks/tests/test_dataset_select_benchmark.py
@@ -1,0 +1,54 @@
+import copy
+import json
+
+import pytest
+
+from .. import _sources
+from .. import dataset_select_benchmark
+from ..tests._asserts import assert_cli, assert_benchmark
+
+
+HELP = """
+Usage: conbench dataset-select [OPTIONS] SOURCE
+
+  Run dataset-select benchmark.
+
+Options:
+  --cpu-count INTEGER
+  --iterations INTEGER   [default: 1]
+  --gc-collect BOOLEAN   [default: true]
+  --gc-disable BOOLEAN   [default: true]
+  --show-result BOOLEAN  [default: true]
+  --show-output BOOLEAN  [default: false]
+  --run-id TEXT          Group executions together with a run id.
+  --help                 Show this message and exit.
+"""
+
+
+nyctaxi = _sources.Source("nyctaxi_multi_parquet_s3_repartitioned")
+benchmark = dataset_select_benchmark.DatasetSelectBenchmark()
+
+
+def assert_run(run, index, benchmark, source):
+    result, output = run[index]
+    assert_benchmark(result, source.name, benchmark.name)
+    print(json.dumps(result, indent=4, sort_keys=True))
+    assert "pyarrow.Table" in str(output)
+
+
+def test_dataset_read_one():
+    [(result, output)] = benchmark.run(nyctaxi, iterations=1)
+    assert_benchmark(result, nyctaxi.name, benchmark.name)
+    print(json.dumps(result, indent=4, sort_keys=True))
+    assert "pyarrow.Table" in str(output)
+
+
+def test_dataset_read_all():
+    run = list(benchmark.run("TEST", iterations=1))
+    assert len(run) == 1
+    assert_run(run, 0, benchmark, nyctaxi)
+
+
+def test_dataset_read_cli():
+    command = ["conbench", "dataset-select", "--help"]
+    assert_cli(command, HELP)

--- a/benchmarks/tests/test_dataset_select_benchmark.py
+++ b/benchmarks/tests/test_dataset_select_benchmark.py
@@ -1,8 +1,6 @@
 import copy
 import json
 
-import pytest
-
 from .. import _sources
 from .. import dataset_select_benchmark
 from ..tests._asserts import assert_cli, assert_benchmark


### PR DESCRIPTION
- Adds a new dataset, which is just the NYC taxi dataset, except with each month split into 101 parts (because I didn't realize I had an off-by-one until I had written everything already)
- Adds a benchmark which selects a single file from the dataset. Unlike dataset-read, we have a partition filter, and unlike dataset-filter, we aren't filtering the dataset itself, hence, the partition filtering machinery is also benchmarked. This targets the scenario in [ARROW-11781](https://issues.apache.org/jira/browse/ARROW-11781). 

This benchmark should run on S3, once I figure out that part.