### PR TITLE
Removed the async tag as it doesn't actually distinguish cases

### DIFF
--- a/benchmarks/dataset_read_benchmark.py
+++ b/benchmarks/dataset_read_benchmark.py
@@ -41,8 +41,6 @@ class DatasetReadBenchmark(_benchmark.Benchmark):
                     filesystem=s3,
                 )
                 supports_async = self._get_supports_async(dataset, format_str)
-                if supports_async:
-                    tags["async"] = supports_async
                 f = self._get_benchmark_function(dataset, supports_async)
                 yield self.benchmark(f, tags, kwargs, case)
                 if legacy:

--- a/benchmarks/tests/test_dataset_read_benchmark.py
+++ b/benchmarks/tests/test_dataset_read_benchmark.py
@@ -46,10 +46,6 @@ cases, case_ids = benchmark.cases, benchmark.case_ids
 def assert_benchmark(result, case, source):
     munged = copy.deepcopy(result)
 
-    # The async tag may or may not be included.  If it is included
-    # the value is always true
-    has_async_tag = "async" in munged["tags"]
-
     legacy = {
         "name": "dataset-read",
         "dataset": source,
@@ -62,10 +58,6 @@ def assert_benchmark(result, case, source):
         "cpu_count": None,
         "pre_buffer": case[0],
     }
-
-    if has_async_tag:
-        legacy["async"] = True
-        pre_buffer["async"] = True
 
     try:
         assert munged["tags"] == pre_buffer


### PR DESCRIPTION
I don't think I really understand the impact of tags when I added the async tag.  In retrospect I think it is best to remove it as it prevents comparisons across history for no real reason.