### PR TITLE
Parameterize the CSV benchmark for compression and streaming

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -6,7 +6,7 @@
     }
   },
   {
-    "command": "csv-read ALL --iterations=3 --drop-caches=true",
+    "command": "csv-read ALL --iterations=3 --all=true --drop-caches=true",
     "flags": {
       "language": "Python"
     }

--- a/benchmarks/csv_read_benchmark.py
+++ b/benchmarks/csv_read_benchmark.py
@@ -12,18 +12,44 @@ class CsvReadBenchmark(_benchmark.Benchmark):
     arguments = ["source"]
     sources = ["fanniemae_2016Q4", "nyctaxi_2010-01"]
     sources_test = ["fanniemae_sample", "nyctaxi_sample"]
+    valid_cases = [("streaming", "compression")] + [
+        ("streaming", "uncompressed"),
+        ("file", "uncompressed"),
+        ("streaming", "gzip"),
+        ("file", "gzip"),
+    ]
 
-    def run(self, source, **kwargs):
+    def run(self, source, case=None, **kwargs):
+        cases = self.get_cases(case, kwargs)
         for source in self.get_sources(source):
-            f = self._get_benchmark_function(
-                source.source_path,
-                source.csv_parse_options,
-            )
-            tags = self.get_tags(kwargs, source)
-            yield self.benchmark(f, tags, kwargs)
+            for case in cases:
+                schema = source.table.schema
+                f = self._get_benchmark_function(source, schema, *case)
+                tags = self.get_tags(kwargs, source)
+                yield self.benchmark(f, tags, kwargs)
 
-    def _get_benchmark_function(self, source_path, parse_options):
-        return lambda: pyarrow.csv.read_csv(
-            source_path,
-            parse_options=parse_options,
-        )
+    def _get_benchmark_function(self, source, schema, streaming, compression):
+        path = source.create_if_not_exists("csv", compression)
+        munged_compression = compression if compression != "uncompressed" else None
+        parse_options = source.csv_parse_options
+        if streaming == "streaming":
+
+            def read_csv_streaming():
+                in_stream = pyarrow.input_stream(path, compression=munged_compression)
+                convert_options = pyarrow.csv.ConvertOptions(column_types=schema)
+                reader = pyarrow.csv.open_csv(
+                    in_stream,
+                    convert_options=convert_options,
+                    parse_options=parse_options,
+                )
+                return reader.read_all()
+
+            return read_csv_streaming
+        else:
+
+            def read_csv_file():
+                in_stream = pyarrow.input_stream(path, compression=munged_compression)
+                table = pyarrow.csv.read_csv(in_stream, parse_options=parse_options)
+                return table
+
+            return read_csv_file

--- a/benchmarks/csv_read_benchmark.py
+++ b/benchmarks/csv_read_benchmark.py
@@ -26,7 +26,7 @@ class CsvReadBenchmark(_benchmark.Benchmark):
                 schema = source.table.schema
                 f = self._get_benchmark_function(source, schema, *case)
                 tags = self.get_tags(kwargs, source)
-                yield self.benchmark(f, tags, kwargs)
+                yield self.benchmark(f, tags, kwargs, case)
 
     def _get_benchmark_function(self, source, schema, streaming, compression):
         path = source.create_if_not_exists("csv", compression)

--- a/benchmarks/tests/test_csv_read_benchmark.py
+++ b/benchmarks/tests/test_csv_read_benchmark.py
@@ -1,40 +1,70 @@
+import copy
+import pytest
+
 from .. import _sources
 from .. import csv_read_benchmark
-from ..tests._asserts import assert_benchmark, assert_cli
+from ..tests._asserts import assert_context, assert_cli
 
 
 HELP = """
 Usage: conbench csv-read [OPTIONS] SOURCE
 
-  Run csv-read benchmark.
+  Run csv-read benchmark(s).
+
+  For each benchmark option, the first option value is the default.
+
+  Valid benchmark combinations:
+  --streaming=streaming --compression=uncompressed
+  --streaming=file --compression=uncompressed
+  --streaming=streaming --compression=gzip
+  --streaming=file --compression=gzip
+
+  To run all combinations:
+  $ conbench csv-read --all=true
 
 Options:
+  --streaming [file|streaming]
+  --compression [gzip|uncompressed]
+  --all BOOLEAN                   [default: False]
   --cpu-count INTEGER
-  --iterations INTEGER   [default: 1]
-  --drop-caches BOOLEAN  [default: False]
-  --gc-collect BOOLEAN   [default: True]
-  --gc-disable BOOLEAN   [default: True]
-  --show-result BOOLEAN  [default: True]
-  --show-output BOOLEAN  [default: False]
-  --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
-  --help                 Show this message and exit.
+  --iterations INTEGER            [default: 1]
+  --drop-caches BOOLEAN           [default: False]
+  --gc-collect BOOLEAN            [default: True]
+  --gc-disable BOOLEAN            [default: True]
+  --show-result BOOLEAN           [default: True]
+  --show-output BOOLEAN           [default: False]
+  --run-id TEXT                   Group executions together with a run id.
+  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --help                          Show this message and exit.
 """
 
 
-def assert_run(run, index, benchmark, source):
+benchmark = csv_read_benchmark.CsvReadBenchmark()
+sources = [_sources.Source(s) for s in benchmark.sources_test]
+cases, case_ids = benchmark.cases, benchmark.case_ids
+
+
+def assert_run(run, index, case, source):
     result, output = run[index]
-    assert_benchmark(result, source.name, benchmark.name)
+    munged = copy.deepcopy(result)
+    expected = {
+        "name": "csv-read",
+        "dataset": source.name,
+        "cpu_count": None,
+        "streaming": case[0],
+        "compression": case[1],
+    }
+    assert munged["tags"] == expected
+    assert_context(munged)
     assert "pyarrow.Table" in str(output)
 
 
-def test_csv_read():
-    benchmark = csv_read_benchmark.CsvReadBenchmark()
-    sources = [_sources.Source(s) for s in benchmark.sources_test]
-    run = list(benchmark.run(sources, iterations=1))
+@pytest.mark.parametrize("case", cases, ids=case_ids)
+def test_csv_read(case):
+    run = list(benchmark.run(sources, case, iterations=1))
     assert len(run) == 2
     for x in range(len(run)):
-        assert_run(run, x, benchmark, sources[x])
+        assert_run(run, x, case, sources[x])
 
 
 def test_csv_read_cli():


### PR DESCRIPTION
Leaving in draft as I'm using pyarrow for the CSV writing but that isn't available on older versions of pyarrow so it would make historical analysis difficult.  We should be able to use pandas for the CSV writing.