### PR TITLE
Use anonymous=True when connecting to public s3 bucket

### DIFF
--- a/benchmarks/dataset_read_benchmark.py
+++ b/benchmarks/dataset_read_benchmark.py
@@ -28,7 +28,7 @@ class DatasetReadBenchmark(_benchmark.Benchmark):
             tags = self.get_tags(kwargs, source)
             format_str = source.format_str
             schema = self._get_schema(source)
-            s3 = pyarrow.fs.S3FileSystem(region=source.region)
+            s3 = pyarrow.fs.S3FileSystem(region=source.region, anonymous=True)
             for case in cases:
                 (pre_buffer,) = case
                 legacy, format_ = self._get_format(pre_buffer, format_str)

--- a/benchmarks/dataset_select_benchmark.py
+++ b/benchmarks/dataset_select_benchmark.py
@@ -23,7 +23,7 @@ class DatasetSelectBenchmark(_benchmark.Benchmark):
             infer_dictionary=True,
         )
         for source in self.get_sources(source):
-            s3 = pyarrow.fs.S3FileSystem(region=source.region)
+            s3 = pyarrow.fs.S3FileSystem(region=source.region, anonymous=True)
             dataset = pyarrow.dataset.dataset(
                 source.paths,
                 format="parquet",


### PR DESCRIPTION
We did not notice this issue until now because we were running these benchmarks on machines without AWS creds.

`dataset-read` and `dataset-select` benchmarks fail when run on AWS resource (e.g., AWS Lambda) with AWS credentials because conbench is trying to access Ursa’s AWS account public s3 bucket (e.g., ursa-labs-taxi-data-repartitioned-10k) using AWS credentials for VD AWS account.


```
Traceback (most recent call last):
File /var/lang/bin/conbench, line 33, in <module>
sys.exit(load_entry_point('conbench==1.0.0', 'console_scripts', 'conbench')())
File /var/lang/lib/python3.8/site-packages/click/core.py, line 1137, in __call__
return self.main(*args, **kwargs)
File /var/lang/lib/python3.8/site-packages/click/core.py, line 1062, in main
rv = self.invoke(ctx)
File /var/lang/lib/python3.8/site-packages/click/core.py, line 1668, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File /var/lang/lib/python3.8/site-packages/click/core.py, line 1404, in invoke
return ctx.invoke(self.callback, **ctx.params)
File /var/lang/lib/python3.8/site-packages/click/core.py, line 763, in invoke
return __callback(*args, **kwargs)
File /var/lang/lib/python3.8/site-packages/conbench-1.0.0-py3.8.egg/conbench/cli.py, line 136, in _benchmark
for result, output in benchmark().run(**kwargs):
File /app/benchmarks/benchmarks/dataset_select_benchmark.py, line 27, in run
dataset = pyarrow.dataset.dataset(
File /var/lang/lib/python3.8/site-packages/pyarrow/dataset.py, line 658, in dataset
return _filesystem_dataset(source, **kwargs)
File /var/lang/lib/python3.8/site-packages/pyarrow/dataset.py, line 410, in _filesystem_dataset
return factory.finish(schema)
File pyarrow/_dataset.pyx, line 2402, in pyarrow._dataset.DatasetFactory.finish
File pyarrow/error.pxi, line 143, in pyarrow.lib.pyarrow_internal_check_status
File pyarrow/error.pxi, line 114, in pyarrow.lib.check_status
OSError: Error creating dataset. Could not read schema from 'ursa-labs-taxi-data-repartitioned-10k/2009/01/0000/data.parquet': When reading information for key '2009/01/0000/data.parquet' in bucket 'ursa-labs-taxi-data-repartitioned-10k': AWS Error [code 15]: No response body.. Is this a 'parquet' file?
```
