### PR TITLE
Handle large stdout produced by benchmarks

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -112,14 +112,17 @@ class Benchmark(conbench.runner.Benchmark):
         )
         return benchmark, output
 
-    def execute_command(self, command):
+    def execute_command(self, command, capture_output=True):
         try:
             print(command)
-            result = subprocess.run(command, capture_output=True, check=True)
+            result = subprocess.run(command, capture_output=capture_output, check=True)
         except subprocess.CalledProcessError as e:
             print(e.stderr.decode("utf-8"))
             raise e
-        return result.stdout.decode("utf-8"), result.stderr.decode("utf-8")
+        # Some benchmarks (e.g., java-micro) produce 12GB+ of stdout that can't be loaded into memory
+        # on benchmark machines with 16GB of RAM and without Swap
+        if capture_output:
+            return result.stdout.decode("utf-8"), result.stderr.decode("utf-8")
 
     def get_sources(self, source):
         if isinstance(source, list):

--- a/benchmarks/java_micro_benchmarks.py
+++ b/benchmarks/java_micro_benchmarks.py
@@ -93,7 +93,7 @@ class RecordJavaMicroBenchmarks(_benchmark.Benchmark):
     def run(self, **kwargs):
         with tempfile.NamedTemporaryFile(delete=False) as result_file:
             run_command = get_run_command(result_file.name, kwargs)
-            self.execute_command(run_command)
+            self.execute_command(run_command, capture_output=False)
             results = json.load(result_file)
 
             # bucket by suite


### PR DESCRIPTION
Java-micro benchmarks started producing more stdout than benchmark machine can load into memory starting with https://github.com/apache/arrow/commit/06fee4545535fc4a1af5c08b4e524ffb89bc7868. This caused benchmark builds running Java benchmarks to fail because `conbench` process running Java-micro benchmarks was killed by OS with exit code 137 (Exit Code 137: Indicates failure as container received SIGKILL (Manual intervention or 'oom-killer' [OUT-OF-MEMORY]).

I decided to handle this issue on benchmarks repo (https://github.com/ursacomputing/benchmarks) side first and then ask Apache Arrow Java community to look into if they can figure out how to reduce amount of stdout for Java-micro benchmarks.

I captured stdout produced by Java-micro benchmarks into a tmp file to see how large it is:

```
root@ursa-thinkcentre-m75q:/home/ursa# grep MemTotal /proc/meminfo
MemTotal:       15787088 kB
root@ursa-thinkcentre-m75q:/home/ursa# free -m
              total        used        free      shared  buff/cache   available
Mem:          15417         566       14611           1         239       14569
Swap:             0           0           0
root@ursa-thinkcentre-m75q:/home/ursa# ls -lh /tmp/tmp*
-rw------- 1 buildkite-agent buildkite-agent 771 Jan  4 13:59 /tmp/tmph_g1zd_v
-rw------- 1 buildkite-agent buildkite-agent 12G Jan  4 14:50 /tmp/tmprjl67dth
-rw------- 1 buildkite-agent buildkite-agent 16K Jan  4 14:50 /tmp/tmpsto7s9_z
root@ursa-thinkcentre-m75q:/home/ursa# python3
Python 3.8.10 (default, Nov 26 2021, 20:14:08) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> open("/tmp/tmprjl67dth").read()
Killed
root@ursa-thinkcentre-m75q:/home/ursa# 
```
