### PR TITLE
JavaScript benchmarks > Ignore non-json stderr produced by benchmarks when loading results

### DIFF
--- a/benchmarks/js_micro_benchmarks.py
+++ b/benchmarks/js_micro_benchmarks.py
@@ -55,7 +55,7 @@ class RecordJavaScriptMicroBenchmarks(_benchmark.Benchmark):
         run_command = get_run_command()
         _, err = self.execute_command(run_command)
         # Ignore non-json stderr produced by JavaScript benchmarks
-        results = json.loads(err[err.find("\n["):])
+        results = json.loads(err[err.find("\n[") :])
 
         # bucket by suite
         suites = {}

--- a/benchmarks/js_micro_benchmarks.py
+++ b/benchmarks/js_micro_benchmarks.py
@@ -54,7 +54,8 @@ class RecordJavaScriptMicroBenchmarks(_benchmark.Benchmark):
 
         run_command = get_run_command()
         _, err = self.execute_command(run_command)
-        results = json.loads(err)
+        # Ignore non-json stderr produced by JavaScript benchmarks
+        results = json.loads(err[err.find("\n["):])
 
         # bucket by suite
         suites = {}

--- a/benchmarks/js_micro_benchmarks.py
+++ b/benchmarks/js_micro_benchmarks.py
@@ -55,7 +55,8 @@ class RecordJavaScriptMicroBenchmarks(_benchmark.Benchmark):
         run_command = get_run_command()
         _, err = self.execute_command(run_command)
         # Ignore non-json stderr produced by JavaScript benchmarks
-        results = json.loads(err[err.find("\n[") :])
+        results_start = err.find("\n[")
+        results = json.loads(err[results_start:])
 
         # bucket by suite
         suites = {}


### PR DESCRIPTION
JavaScript benchmarks started to output non-json logs in `stderr` in addition to actual results starting with https://github.com/apache/arrow/commit/20b66c255ff617c438775e54081eaa02d5b983e1.

This broke the code that tries to capture benchmark results from stderr.

I will be creating an Apache Arrow story (if it is not already created yet) to log JavaScript benchmark results into a tmp file instead stderr so we can avoid issues like this in the future.

Here is how JavaScript benchmarks stderr looks like since https://github.com/apache/arrow/commit/20b66c255ff617c438775e54081eaa02d5b983e1:
```
(node:1346319) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
[
  {
    "name": "from: numbers",
    "ops": 81.65759819570866,
    "margin": 1.73,
    "options": {
      "delay": 0.005,
      "initCount": 1,
      "minTime": 0.05,
      "maxTime": 5,
      "minSamples": 5
    },
...
```