### PR TITLE
[ENG-3649] Add R csv benchmarks

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -92,6 +92,12 @@
     }
   },
   {
+    "command": "r-csv-read --iterations=3 --all=true --drop-caches=true",
+    "flags": {
+      "language": "R"
+    }
+  },
+  {
     "command": "tpch --iterations=3 --all=true --drop-caches=true",
     "flags": {
       "language": "R"

--- a/benchmarks/_sources.py
+++ b/benchmarks/_sources.py
@@ -216,14 +216,14 @@ def bytes_fmt(value):
         return None
     if value == 0:
         return "0"
-    if value < 1024 ** 2:
+    if value < 1024**2:
         return "small"
-    if value < 1024 ** 3:
-        return "{:.0f} Mi".format(value / 1024 ** 2)
-    if value < 1024 ** 4:
-        return "{:.1f} Gi".format(value / 1024 ** 3)
+    if value < 1024**3:
+        return "{:.0f} Mi".format(value / 1024**2)
+    if value < 1024**4:
+        return "{:.1f} Gi".format(value / 1024**3)
     else:
-        return "{:.1f} Ti".format(value / 1024 ** 4)
+        return "{:.1f} Ti".format(value / 1024**4)
 
 
 class Source:

--- a/benchmarks/r_csv_read_benchmark.py
+++ b/benchmarks/r_csv_read_benchmark.py
@@ -10,12 +10,12 @@ class RCsvReadBenchmark(_benchmark.BenchmarkR):
     external, r_only = True, True
     name, r_name = "r-csv-read", "read_csv"
     valid_cases = [
-        ('source', 'compression', 'output'),
+        ("source", "compression", "output"),
         *itertools.product(
-            ['fanniemae_2016Q4', 'nyctaxi_2010-01', 'chi_traffic_2020_Q1'],
-            ['uncompressed', 'gzip'],
-            ['arrow_table', 'data_frame']
-        )
+            ["fanniemae_2016Q4", "nyctaxi_2010-01", "chi_traffic_2020_Q1"],
+            ["uncompressed", "gzip"],
+            ["arrow_table", "data_frame"],
+        ),
     ]
 
     def run(self, case=None, **kwargs):
@@ -23,8 +23,8 @@ class RCsvReadBenchmark(_benchmark.BenchmarkR):
 
         for case in self.get_cases(case, kwargs):
             tags = self.get_tags(kwargs)
-            tags['source'] = case[0]
-            tags["reader"] = 'arrow'
+            tags["source"] = case[0]
+            tags["reader"] = "arrow"
             tags["compression"] = case[1]
             tags["output"] = case[2]
             self._manually_batch(kwargs, case)
@@ -32,8 +32,8 @@ class RCsvReadBenchmark(_benchmark.BenchmarkR):
             yield self.r_benchmark(command, tags, kwargs, case)
 
     def _set_defaults(self, options):
-        options["source"] = options.get("source", 'fanniemae_2016Q4')
-        options["compression"] = options.get("compression", 'uncompressed')
+        options["source"] = options.get("source", "fanniemae_2016Q4")
+        options["compression"] = options.get("compression", "uncompressed")
         options["output"] = options.get("output", "arrow_table")
 
     def _manually_batch(self, options, case):

--- a/benchmarks/r_csv_read_benchmark.py
+++ b/benchmarks/r_csv_read_benchmark.py
@@ -1,0 +1,60 @@
+import itertools
+
+import conbench.runner
+
+from benchmarks import _benchmark
+
+
+@conbench.runner.register_benchmark
+class RCsvReadBenchmark(_benchmark.BenchmarkR):
+    external, r_only = True, True
+    name, r_name = "r-csv-read", "read_csv"
+    valid_cases = [
+        ('source', 'compression', 'output'),
+        *itertools.product(
+            ['fanniemae_2016Q4', 'nyctaxi_2010-01', 'chi_traffic_2020_Q1'],
+            ['uncompressed', 'gzip'],
+            ['arrow_table', 'data_frame']
+        )
+    ]
+
+    def run(self, case=None, **kwargs):
+        self._set_defaults(kwargs)
+
+        for case in self.get_cases(case, kwargs):
+            tags = self.get_tags(kwargs)
+            tags['source'] = case[0]
+            tags["reader"] = 'arrow'
+            tags["compression"] = case[1]
+            tags["output"] = case[2]
+            self._manually_batch(kwargs, case)
+            command = self._get_r_command(kwargs, case)
+            yield self.r_benchmark(command, tags, kwargs, case)
+
+    def _set_defaults(self, options):
+        options["source"] = options.get("source", 'fanniemae_2016Q4')
+        options["compression"] = options.get("compression", 'uncompressed')
+        options["output"] = options.get("output", "arrow_table")
+
+    def _manually_batch(self, options, case):
+        # manually batch so that the batch plots display
+        (source, compression, output) = case
+        run_id = self.conbench.get_run_id(options)
+        batch_id = f"{run_id}-{source}-{compression}-{output}"
+        self.conbench.manually_batch(batch_id)
+
+    def _get_r_command(self, options, case):
+        params = {
+            parameter: argument
+            for parameter, argument in zip(self.valid_cases[0], case)
+        }
+
+        return (
+            f"library(arrowbench); "
+            f"run_one({self.r_name}, "
+            f"cpu_count={self.r_cpu_count(options)}, "
+            f"source=\"{params['source']}\", "
+            f"reader='arrow', "
+            f"compression=\"{params['compression']}\", "
+            f"output=\"{params['output']}\")"
+        )

--- a/benchmarks/tests/test_r_csv_read_benchmark.py
+++ b/benchmarks/tests/test_r_csv_read_benchmark.py
@@ -57,7 +57,7 @@ def assert_benchmark(result, name, language="Python"):
         expected["language"] = "R"
     assert munged["tags"] == expected
     assert result["run_id"] == "some-run-id"
-    assert result["batch_id"] == 'some-run-id-fanniemae_2016Q4-uncompressed-arrow_table'
+    assert result["batch_id"] == "some-run-id-fanniemae_2016Q4-uncompressed-arrow_table"
     _asserts.assert_info_and_context(munged, language=language)
 
 

--- a/benchmarks/tests/test_r_csv_read_benchmark.py
+++ b/benchmarks/tests/test_r_csv_read_benchmark.py
@@ -1,0 +1,74 @@
+import copy
+
+from .. import r_csv_read_benchmark
+from ..tests import _asserts
+
+HELP = """
+Usage: conbench r-csv-read [OPTIONS]
+
+  Run r-csv-read benchmark(s).
+
+  For each benchmark option, the first option value is the default.
+
+  Valid benchmark combinations:
+  --source=fanniemae_2016Q4 --compression=uncompressed --output=arrow_table
+  --source=fanniemae_2016Q4 --compression=uncompressed --output=data_frame
+  --source=fanniemae_2016Q4 --compression=gzip --output=arrow_table
+  --source=fanniemae_2016Q4 --compression=gzip --output=data_frame
+  --source=nyctaxi_2010-01 --compression=uncompressed --output=arrow_table
+  --source=nyctaxi_2010-01 --compression=uncompressed --output=data_frame
+  --source=nyctaxi_2010-01 --compression=gzip --output=arrow_table
+  --source=nyctaxi_2010-01 --compression=gzip --output=data_frame
+  --source=chi_traffic_2020_Q1 --compression=uncompressed --output=arrow_table
+  --source=chi_traffic_2020_Q1 --compression=uncompressed --output=data_frame
+  --source=chi_traffic_2020_Q1 --compression=gzip --output=arrow_table
+  --source=chi_traffic_2020_Q1 --compression=gzip --output=data_frame
+
+  To run all combinations:
+  $ conbench r-csv-read --all=true
+
+Options:
+  --source [chi_traffic_2020_Q1|fanniemae_2016Q4|nyctaxi_2010-01]
+  --compression [gzip|uncompressed]
+  --output [arrow_table|data_frame]
+  --all BOOLEAN                   [default: false]
+  --iterations INTEGER            [default: 1]
+  --drop-caches BOOLEAN           [default: false]
+  --cpu-count INTEGER
+  --show-result BOOLEAN           [default: true]
+  --show-output BOOLEAN           [default: false]
+  --run-id TEXT                   Group executions together with a run id.
+  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --help                          Show this message and exit.
+"""
+
+
+def assert_benchmark(result, name, language="Python"):
+    munged = copy.deepcopy(result)
+    expected = {
+        "name": name,
+        "cpu_count": None,
+        "source": "fanniemae_2016Q4",
+        "reader": "arrow",
+        "compression": "uncompressed",
+        "output": "arrow_table",
+    }
+    if language == "R":
+        expected["language"] = "R"
+    assert munged["tags"] == expected
+    assert result["run_id"] == "some-run-id"
+    assert result["batch_id"] == 'some-run-id-fanniemae_2016Q4-uncompressed-arrow_table'
+    _asserts.assert_info_and_context(munged, language=language)
+
+
+def test_benchmark_r():
+    benchmark = r_csv_read_benchmark.RCsvReadBenchmark()
+    run_id = "some-run-id"
+    [(result, output)] = benchmark.run(iterations=1, run_id=run_id)
+    assert_benchmark(result, benchmark.name, language="R")
+    assert _asserts.R_CLI in str(output)
+
+
+def test_cli():
+    command = ["conbench", "r-csv-read", "--help"]
+    _asserts.assert_cli(command, HELP)


### PR DESCRIPTION
Closes #37 by adding an `RCsvReadBenchmark` class that runs [the arrowbench `read_csv` benchmark](https://github.com/ursacomputing/arrowbench/blob/main/R/bm-read-csv.R). Tried to stay reasonably parallel to the Python version; took the naming convention from the benchmarks in other languages.