### PR TITLE
[ENG-3649] Add R csv benchmarks

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -12,6 +12,12 @@
     }
   },
   {
+    "command": "csv-read ALL --iterations=3 --all=true --drop-caches=true --language=R",
+    "flags": {
+      "language": "R"
+    }
+  },
+  {
     "command": "dataframe-to-table ALL --iterations=3 --drop-caches=true",
     "flags": {
       "language": "Python"

--- a/benchmarks/_sources.py
+++ b/benchmarks/_sources.py
@@ -216,14 +216,14 @@ def bytes_fmt(value):
         return None
     if value == 0:
         return "0"
-    if value < 1024 ** 2:
+    if value < 1024**2:
         return "small"
-    if value < 1024 ** 3:
-        return "{:.0f} Mi".format(value / 1024 ** 2)
-    if value < 1024 ** 4:
-        return "{:.1f} Gi".format(value / 1024 ** 3)
+    if value < 1024**3:
+        return "{:.0f} Mi".format(value / 1024**2)
+    if value < 1024**4:
+        return "{:.1f} Gi".format(value / 1024**3)
     else:
-        return "{:.1f} Ti".format(value / 1024 ** 4)
+        return "{:.1f} Ti".format(value / 1024**4)
 
 
 class Source:

--- a/benchmarks/csv_read_benchmark.py
+++ b/benchmarks/csv_read_benchmark.py
@@ -1,3 +1,5 @@
+import itertools
+
 import conbench.runner
 import pyarrow.csv
 
@@ -5,29 +7,51 @@ from benchmarks import _benchmark
 
 
 @conbench.runner.register_benchmark
-class CsvReadBenchmark(_benchmark.Benchmark):
-    """Read CSV file to arrow table."""
+class CsvReadBenchmark(_benchmark.BenchmarkPythonR):
+    """Read CSV file."""
 
     name = "csv-read"
+    r_name = "read_csv"
     arguments = ["source"]
     sources = ["fanniemae_2016Q4", "nyctaxi_2010-01"]
     sources_test = ["fanniemae_sample", "nyctaxi_sample"]
-    valid_cases = [("streaming", "compression")] + [
-        ("streaming", "uncompressed"),
-        ("file", "uncompressed"),
-        ("streaming", "gzip"),
-        ("file", "gzip"),
+    valid_python_cases = list(
+        itertools.product(
+            ["streaming", "file"], ["uncompressed", "gzip"], ["arrow_table"]
+        )
+    )
+    valid_r_cases = list(
+        itertools.product(
+            ["file"], ["uncompressed", "gzip"], ["arrow_table", "data_frame"]
+        )
+    )
+    valid_cases = [
+        ("streaming", "compression", "output"),
+        *sorted({*valid_python_cases, *valid_r_cases}),
     ]
 
     def run(self, source, case=None, **kwargs):
         cases = self.get_cases(case, kwargs)
-        for source in self.get_sources(source):
-            for case in cases:
-                f = self._get_benchmark_function(source, *case)
-                tags = self.get_tags(kwargs, source)
-                yield self.benchmark(f, tags, kwargs, case)
+        language = kwargs.get("language", "Python").lower()
 
-    def _get_benchmark_function(self, source, streaming, compression):
+        for source in self.get_sources(source):
+            tags = self.get_tags(kwargs, source)
+
+            for case in cases:
+                if language == "python":
+                    if case not in self.valid_python_cases:
+                        continue
+                    f = self._get_benchmark_function(source, *case)
+                    yield self.benchmark(f, tags, kwargs, case)
+                elif language == "r":
+                    if case not in self.valid_r_cases:
+                        continue
+                    command = self._get_r_command(source, case, kwargs)
+                    yield self.r_benchmark(
+                        command=command, extra_tags=tags, options=kwargs, case=case
+                    )
+
+    def _get_benchmark_function(self, source, streaming, compression, output):
         # Note: this will write a comma separated csv with a header, even if
         # the original source file lacked a header and was pipe delimited.
         path = source.create_if_not_exists("csv", compression)
@@ -49,3 +73,24 @@ class CsvReadBenchmark(_benchmark.Benchmark):
             return table
 
         return read_streaming if streaming == "streaming" else read_file
+
+    def _get_r_command(self, source, case, options):
+        params = self._case_to_param_dict(case=case)
+
+        return (
+            f"library(arrowbench); "
+            f"run_one({self.r_name}, "
+            f"cpu_count={self.r_cpu_count(options)}, "
+            f'source="{source.name}", '
+            f"reader='arrow', "
+            f"compression=\"{params['compression']}\", "
+            f"output=\"{params['output']}\")"
+        )
+
+    def _case_to_param_dict(self, case):
+        params = {
+            parameter: argument
+            for parameter, argument in zip(self.valid_cases[0], case)
+        }
+
+        return params

--- a/benchmarks/tests/test_csv_read_benchmark.py
+++ b/benchmarks/tests/test_csv_read_benchmark.py
@@ -1,5 +1,4 @@
 import copy
-from re import L
 
 import pytest
 


### PR DESCRIPTION
Take 2. Closes #37 by changing the `CsvReadBenchmark` to inherit from `BenchmarkPythonR` instead of `Benchmark` and adjusting it so it runs [the `read_csv` benchmark from {arrowbench}](https://github.com/ursacomputing/arrowbench/blob/main/R/bm-read-csv.R).

Because the viable cases differ between Python and R (py has streaming, R has dataframe output), the class maintains separate lists of which cases are viable for each language and skips those that aren't. I took this approach because language is not part of case in the parent class. Maybe there's a more elegant alternative?