### PR TITLE
Change output format name in csv-read

### DIFF
--- a/benchmarks/csv_benchmark.py
+++ b/benchmarks/csv_benchmark.py
@@ -41,7 +41,7 @@ class CsvBenchmark(_benchmark.BenchmarkPythonR):
         if self.name == "csv-read":
             # TODO: remove once compression available for writing
             compression = f"compression=\"{params['compression']}\", "
-            io_type = "output"
+            io_type = "output_format"
         elif self.name == "csv-write":
             compression = ""
             io_type = "input"
@@ -85,12 +85,12 @@ class CsvReadBenchmark(CsvBenchmark):
         )
     )
     valid_cases = [
-        ("streaming", "compression", "output"),
+        ("streaming", "compression", "output_format"),
         *sorted({*valid_python_cases, *valid_r_cases}),
     ]
 
     def _get_benchmark_function(
-        self, source, streaming, compression, output
+        self, source, streaming, compression, output_format
     ) -> Callable:
         # Note: this will write a comma separated csv with a header, even if
         # the original source file lacked a header and was pipe delimited.

--- a/benchmarks/tests/test_csv_benchmark.py
+++ b/benchmarks/tests/test_csv_benchmark.py
@@ -51,12 +51,12 @@ class TestCsvReadBenchmark(TestCsvBenchmark):
   For each benchmark option, the first option value is the default.
 
   Valid benchmark combinations:
-  --streaming=file --compression=gzip --output=arrow_table
-  --streaming=file --compression=gzip --output=data_frame
-  --streaming=file --compression=uncompressed --output=arrow_table
-  --streaming=file --compression=uncompressed --output=data_frame
-  --streaming=streaming --compression=gzip --output=arrow_table
-  --streaming=streaming --compression=uncompressed --output=arrow_table
+  --streaming=file --compression=gzip --output-format=arrow_table
+  --streaming=file --compression=gzip --output-format=data_frame
+  --streaming=file --compression=uncompressed --output-format=arrow_table
+  --streaming=file --compression=uncompressed --output-format=data_frame
+  --streaming=streaming --compression=gzip --output-format=arrow_table
+  --streaming=streaming --compression=uncompressed --output-format=arrow_table
 
   To run all combinations:
   $ conbench csv-read --all=true
@@ -64,7 +64,7 @@ class TestCsvReadBenchmark(TestCsvBenchmark):
 Options:
   --streaming [file|streaming]
   --compression [gzip|uncompressed]
-  --output [arrow_table|data_frame]
+  --output-format [arrow_table|data_frame]
   --all BOOLEAN                   [default: false]
   --language [Python|R]
   --cpu-count INTEGER


### PR DESCRIPTION
See [comment](https://github.com/ursacomputing/arrowbench/pull/90/#discussion_r876196434). This change is to keep {benchmarks} in sync with {arrowbench}. [This PR](https://github.com/ursacomputing/arrowbench/pull/90) changes the `output` parameter in `read_csv` to be called `output_format`, because otherwise the name later conflicts with the captured output.