### PR TITLE
Hotfix: Renamed query in R dataset benchmark

### DIFF
--- a/benchmarks/partitioned_dataset_filter_benchmark.py
+++ b/benchmarks/partitioned_dataset_filter_benchmark.py
@@ -14,7 +14,7 @@ class PartitionedDatasetFilterBenchmark(_benchmark.BenchmarkR):
         ["vignette"],
         ["payment_type_3"],
         ["small_no_files"],
-        ["count_rows"],
+        ["dims"],
     )
 
     def run(self, case=None, **kwargs):

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -24,7 +24,10 @@ Options:
   --show-result BOOLEAN      [default: true]
   --show-output BOOLEAN      [default: false]
   --run-id TEXT              Group executions together with a run id.
-  --run-name TEXT            Name of run (commit, pull request, etc).
+  --run-name TEXT            Free-text name of run (commit ABC, pull request
+                             123, etc).
+  --run-reason TEXT          Low-cardinality reason for run (commit, pull
+                             request, manual, etc).
   --help                     Show this message and exit.
 """
 

--- a/benchmarks/tests/test_csv_benchmark.py
+++ b/benchmarks/tests/test_csv_benchmark.py
@@ -44,7 +44,7 @@ class TestCsvReadBenchmark(TestCsvBenchmark):
     cases, case_ids = benchmark.cases, benchmark.case_ids
 
     HELP = """
-    Usage: conbench csv-read [OPTIONS] SOURCE
+  Usage: conbench csv-read [OPTIONS] SOURCE
 
   Run csv-read benchmark(s).
 
@@ -75,7 +75,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
     """
 
@@ -136,7 +139,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
     """
 

--- a/benchmarks/tests/test_dataframe_to_table_benchmark.py
+++ b/benchmarks/tests/test_dataframe_to_table_benchmark.py
@@ -18,7 +18,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/benchmarks/tests/test_dataset_filter_benchhmark.py
+++ b/benchmarks/tests/test_dataset_filter_benchhmark.py
@@ -15,7 +15,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/benchmarks/tests/test_dataset_read_benchmark.py
+++ b/benchmarks/tests/test_dataset_read_benchmark.py
@@ -30,7 +30,10 @@ Options:
   --show-result BOOLEAN      [default: true]
   --show-output BOOLEAN      [default: false]
   --run-id TEXT              Group executions together with a run id.
-  --run-name TEXT            Name of run (commit, pull request, etc).
+  --run-name TEXT            Free-text name of run (commit ABC, pull request
+                             123, etc).
+  --run-reason TEXT          Low-cardinality reason for run (commit, pull
+                             request, manual, etc).
   --help                     Show this message and exit.
 """
 

--- a/benchmarks/tests/test_dataset_select_benchmark.py
+++ b/benchmarks/tests/test_dataset_select_benchmark.py
@@ -15,7 +15,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/benchmarks/tests/test_dataset_selectivity_benchmark.py
+++ b/benchmarks/tests/test_dataset_selectivity_benchmark.py
@@ -31,7 +31,10 @@ Options:
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]
   --run-id TEXT                Group executions together with a run id.
-  --run-name TEXT              Name of run (commit, pull request, etc).
+  --run-name TEXT              Free-text name of run (commit ABC, pull request
+                               123, etc).
+  --run-reason TEXT            Low-cardinality reason for run (commit, pull
+                               request, manual, etc).
   --help                       Show this message and exit.
 """
 

--- a/benchmarks/tests/test_example_benchmarks.py
+++ b/benchmarks/tests/test_example_benchmarks.py
@@ -19,7 +19,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -33,7 +36,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -49,7 +55,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -81,7 +90,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/benchmarks/tests/test_file_benchmark.py
+++ b/benchmarks/tests/test_file_benchmark.py
@@ -39,7 +39,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
 """
 
@@ -77,7 +80,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
 """
 

--- a/benchmarks/tests/test_java_micro_benchmarks.py
+++ b/benchmarks/tests/test_java_micro_benchmarks.py
@@ -20,7 +20,10 @@ Options:
   --show-result BOOLEAN    [default: true]
   --show-output BOOLEAN    [default: false]
   --run-id TEXT            Group executions together with a run id.
-  --run-name TEXT          Name of run (commit, pull request, etc).
+  --run-name TEXT          Free-text name of run (commit ABC, pull request
+                           123, etc).
+  --run-reason TEXT        Low-cardinality reason for run (commit, pull
+                           request, manual, etc).
   --help                   Show this message and exit.
 """
 

--- a/benchmarks/tests/test_js_micro_benchmarks.py
+++ b/benchmarks/tests/test_js_micro_benchmarks.py
@@ -15,7 +15,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/benchmarks/tests/test_partitioned_dataset_filter_benchmark.py
+++ b/benchmarks/tests/test_partitioned_dataset_filter_benchmark.py
@@ -16,13 +16,13 @@ Usage: conbench partitioned-dataset-filter [OPTIONS]
   --query=vignette
   --query=payment_type_3
   --query=small_no_files
-  --query=count_rows
+  --query=dims
 
   To run all combinations:
   $ conbench partitioned-dataset-filter --all=true
 
 Options:
-  --query [count_rows|payment_type_3|small_no_files|vignette]
+  --query [dims|payment_type_3|small_no_files|vignette]
   --all BOOLEAN                   [default: false]
   --iterations INTEGER            [default: 1]
   --drop-caches BOOLEAN           [default: false]

--- a/benchmarks/tests/test_partitioned_dataset_filter_benchmark.py
+++ b/benchmarks/tests/test_partitioned_dataset_filter_benchmark.py
@@ -30,7 +30,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
 """
 

--- a/benchmarks/tests/test_tpch_benchmark.py
+++ b/benchmarks/tests/test_tpch_benchmark.py
@@ -114,7 +114,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
 """
 

--- a/benchmarks/tests/test_wide_dataframe_benchmark.py
+++ b/benchmarks/tests/test_wide_dataframe_benchmark.py
@@ -30,7 +30,10 @@ Options:
   --show-result BOOLEAN           [default: true]
   --show-output BOOLEAN           [default: false]
   --run-id TEXT                   Group executions together with a run id.
-  --run-name TEXT                 Name of run (commit, pull request, etc).
+  --run-name TEXT                 Free-text name of run (commit ABC, pull
+                                  request 123, etc).
+  --run-reason TEXT               Low-cardinality reason for run (commit, pull
+                                  request, manual, etc).
   --help                          Show this message and exit.
 """
 


### PR DESCRIPTION
I broke things with https://github.com/ursacomputing/arrowbench/pull/106 (specifically [here](https://github.com/ursacomputing/arrowbench/pull/106/files#diff-8b62164b35e55affb72f6d95ddc3945e7e8dde444917d3a572858a7ff5537ce6)) by changing a query name from `count_rows` to `dims` (because it checks number of cols in addition to rows). This PR makes the accompanying change in {benchmarks} so it will pass the right argument.