### PR TITLE
Add Python case versioning capability

### DIFF
--- a/benchmarks/_example_benchmarks.py
+++ b/benchmarks/_example_benchmarks.py
@@ -80,7 +80,15 @@ class CasesBenchmark(_benchmark.Benchmark):
     )
 
     def version_case(self, case: tuple):
-        return 2 * int(case[0]) + int(case[1])
+        # A lookup like this might be a common way to store versions, but any logic here
+        # (e.g. `2 if case[0] == "2" else 1`) is fine!
+        case_versions = {
+            ("10", "10"): 1,
+            ("2", "10"): 2,
+            ("10", "2"): 1,
+        }
+
+        return case_versions[case]
 
     def run(self, case=None, **kwargs):
         tags = self.get_tags(kwargs)
@@ -143,7 +151,15 @@ class CasesBenchmarkException(_benchmark.Benchmark):
     )
 
     def version_case(self, case: tuple):
-        return 2 * int(case[0]) + int(case[1])
+        # A lookup like this might be a common way to store versions, but any logic here
+        # (e.g. `2 if case[0] == "2" else 1`) is fine!
+        case_versions = {
+            ("10", "10"): 1,
+            ("2", "10"): 2,
+            ("10", "2"): 1,
+        }
+
+        return case_versions[case]
 
     def run(self, case=None, **kwargs):
         tags = self.get_tags(kwargs)

--- a/benchmarks/_example_benchmarks.py
+++ b/benchmarks/_example_benchmarks.py
@@ -79,6 +79,9 @@ class CasesBenchmark(_benchmark.Benchmark):
         ("10", "2"),
     )
 
+    def version_case(self, case: tuple):
+        return 2 * int(case[0]) + int(case[1])
+
     def run(self, case=None, **kwargs):
         tags = self.get_tags(kwargs)
         for case in self.get_cases(case, kwargs):
@@ -138,6 +141,9 @@ class CasesBenchmarkException(_benchmark.Benchmark):
         ("2", "10"),
         ("10", "2"),
     )
+
+    def version_case(self, case: tuple):
+        return 2 * int(case[0]) + int(case[1])
 
     def run(self, case=None, **kwargs):
         tags = self.get_tags(kwargs)

--- a/benchmarks/tests/test_example_benchmarks.py
+++ b/benchmarks/tests/test_example_benchmarks.py
@@ -191,7 +191,7 @@ def assert_cases_benchmark(result, case):
         "cpu_count": None,
         "rows": case[0],
         "columns": case[1],
-        "case_version": 2 * int(case[0]) + int(case[1]),
+        "case_version": 2 if case[0] == "2" else 1,
     }
     _asserts.assert_info_and_context(munged)
 
@@ -206,7 +206,7 @@ def assert_cases_benchmark_exception(result, case):
         "cpu_count": None,
         "rows": case[0],
         "columns": case[1],
-        "case_version": 2 * int(case[0]) + int(case[1]),
+        "case_version": 2 if case[0] == "2" else 1,
     }
     assert munged["tags"] == expected_tags
 

--- a/benchmarks/tests/test_example_benchmarks.py
+++ b/benchmarks/tests/test_example_benchmarks.py
@@ -191,6 +191,7 @@ def assert_cases_benchmark(result, case):
         "cpu_count": None,
         "rows": case[0],
         "columns": case[1],
+        "case_version": 2 * int(case[0]) + int(case[1]),
     }
     _asserts.assert_info_and_context(munged)
 
@@ -205,6 +206,7 @@ def assert_cases_benchmark_exception(result, case):
         "cpu_count": None,
         "rows": case[0],
         "columns": case[1],
+        "case_version": 2 * int(case[0]) + int(case[1]),
     }
     assert munged["tags"] == expected_tags
 

--- a/benchmarks/tests/test_tpch_benchmark.py
+++ b/benchmarks/tests/test_tpch_benchmark.py
@@ -11,90 +11,178 @@ Usage: conbench tpch [OPTIONS]
   For each benchmark option, the first option value is the default.
 
   Valid benchmark combinations:
+  --query-id=1 --scale-factor=0.01 --format=native
+  --query-id=1 --scale-factor=0.01 --format=parquet
+  --query-id=1 --scale-factor=0.1 --format=native
+  --query-id=1 --scale-factor=0.1 --format=parquet
   --query-id=1 --scale-factor=1 --format=native
   --query-id=1 --scale-factor=1 --format=parquet
   --query-id=1 --scale-factor=10 --format=native
   --query-id=1 --scale-factor=10 --format=parquet
+  --query-id=2 --scale-factor=0.01 --format=native
+  --query-id=2 --scale-factor=0.01 --format=parquet
+  --query-id=2 --scale-factor=0.1 --format=native
+  --query-id=2 --scale-factor=0.1 --format=parquet
   --query-id=2 --scale-factor=1 --format=native
   --query-id=2 --scale-factor=1 --format=parquet
   --query-id=2 --scale-factor=10 --format=native
   --query-id=2 --scale-factor=10 --format=parquet
+  --query-id=3 --scale-factor=0.01 --format=native
+  --query-id=3 --scale-factor=0.01 --format=parquet
+  --query-id=3 --scale-factor=0.1 --format=native
+  --query-id=3 --scale-factor=0.1 --format=parquet
   --query-id=3 --scale-factor=1 --format=native
   --query-id=3 --scale-factor=1 --format=parquet
   --query-id=3 --scale-factor=10 --format=native
   --query-id=3 --scale-factor=10 --format=parquet
+  --query-id=4 --scale-factor=0.01 --format=native
+  --query-id=4 --scale-factor=0.01 --format=parquet
+  --query-id=4 --scale-factor=0.1 --format=native
+  --query-id=4 --scale-factor=0.1 --format=parquet
   --query-id=4 --scale-factor=1 --format=native
   --query-id=4 --scale-factor=1 --format=parquet
   --query-id=4 --scale-factor=10 --format=native
   --query-id=4 --scale-factor=10 --format=parquet
+  --query-id=5 --scale-factor=0.01 --format=native
+  --query-id=5 --scale-factor=0.01 --format=parquet
+  --query-id=5 --scale-factor=0.1 --format=native
+  --query-id=5 --scale-factor=0.1 --format=parquet
   --query-id=5 --scale-factor=1 --format=native
   --query-id=5 --scale-factor=1 --format=parquet
   --query-id=5 --scale-factor=10 --format=native
   --query-id=5 --scale-factor=10 --format=parquet
+  --query-id=6 --scale-factor=0.01 --format=native
+  --query-id=6 --scale-factor=0.01 --format=parquet
+  --query-id=6 --scale-factor=0.1 --format=native
+  --query-id=6 --scale-factor=0.1 --format=parquet
   --query-id=6 --scale-factor=1 --format=native
   --query-id=6 --scale-factor=1 --format=parquet
   --query-id=6 --scale-factor=10 --format=native
   --query-id=6 --scale-factor=10 --format=parquet
+  --query-id=7 --scale-factor=0.01 --format=native
+  --query-id=7 --scale-factor=0.01 --format=parquet
+  --query-id=7 --scale-factor=0.1 --format=native
+  --query-id=7 --scale-factor=0.1 --format=parquet
   --query-id=7 --scale-factor=1 --format=native
   --query-id=7 --scale-factor=1 --format=parquet
   --query-id=7 --scale-factor=10 --format=native
   --query-id=7 --scale-factor=10 --format=parquet
+  --query-id=8 --scale-factor=0.01 --format=native
+  --query-id=8 --scale-factor=0.01 --format=parquet
+  --query-id=8 --scale-factor=0.1 --format=native
+  --query-id=8 --scale-factor=0.1 --format=parquet
   --query-id=8 --scale-factor=1 --format=native
   --query-id=8 --scale-factor=1 --format=parquet
   --query-id=8 --scale-factor=10 --format=native
   --query-id=8 --scale-factor=10 --format=parquet
+  --query-id=9 --scale-factor=0.01 --format=native
+  --query-id=9 --scale-factor=0.01 --format=parquet
+  --query-id=9 --scale-factor=0.1 --format=native
+  --query-id=9 --scale-factor=0.1 --format=parquet
   --query-id=9 --scale-factor=1 --format=native
   --query-id=9 --scale-factor=1 --format=parquet
   --query-id=9 --scale-factor=10 --format=native
   --query-id=9 --scale-factor=10 --format=parquet
+  --query-id=10 --scale-factor=0.01 --format=native
+  --query-id=10 --scale-factor=0.01 --format=parquet
+  --query-id=10 --scale-factor=0.1 --format=native
+  --query-id=10 --scale-factor=0.1 --format=parquet
   --query-id=10 --scale-factor=1 --format=native
   --query-id=10 --scale-factor=1 --format=parquet
   --query-id=10 --scale-factor=10 --format=native
   --query-id=10 --scale-factor=10 --format=parquet
+  --query-id=11 --scale-factor=0.01 --format=native
+  --query-id=11 --scale-factor=0.01 --format=parquet
+  --query-id=11 --scale-factor=0.1 --format=native
+  --query-id=11 --scale-factor=0.1 --format=parquet
   --query-id=11 --scale-factor=1 --format=native
   --query-id=11 --scale-factor=1 --format=parquet
   --query-id=11 --scale-factor=10 --format=native
   --query-id=11 --scale-factor=10 --format=parquet
+  --query-id=12 --scale-factor=0.01 --format=native
+  --query-id=12 --scale-factor=0.01 --format=parquet
+  --query-id=12 --scale-factor=0.1 --format=native
+  --query-id=12 --scale-factor=0.1 --format=parquet
   --query-id=12 --scale-factor=1 --format=native
   --query-id=12 --scale-factor=1 --format=parquet
   --query-id=12 --scale-factor=10 --format=native
   --query-id=12 --scale-factor=10 --format=parquet
+  --query-id=13 --scale-factor=0.01 --format=native
+  --query-id=13 --scale-factor=0.01 --format=parquet
+  --query-id=13 --scale-factor=0.1 --format=native
+  --query-id=13 --scale-factor=0.1 --format=parquet
   --query-id=13 --scale-factor=1 --format=native
   --query-id=13 --scale-factor=1 --format=parquet
   --query-id=13 --scale-factor=10 --format=native
   --query-id=13 --scale-factor=10 --format=parquet
+  --query-id=14 --scale-factor=0.01 --format=native
+  --query-id=14 --scale-factor=0.01 --format=parquet
+  --query-id=14 --scale-factor=0.1 --format=native
+  --query-id=14 --scale-factor=0.1 --format=parquet
   --query-id=14 --scale-factor=1 --format=native
   --query-id=14 --scale-factor=1 --format=parquet
   --query-id=14 --scale-factor=10 --format=native
   --query-id=14 --scale-factor=10 --format=parquet
+  --query-id=15 --scale-factor=0.01 --format=native
+  --query-id=15 --scale-factor=0.01 --format=parquet
+  --query-id=15 --scale-factor=0.1 --format=native
+  --query-id=15 --scale-factor=0.1 --format=parquet
   --query-id=15 --scale-factor=1 --format=native
   --query-id=15 --scale-factor=1 --format=parquet
   --query-id=15 --scale-factor=10 --format=native
   --query-id=15 --scale-factor=10 --format=parquet
+  --query-id=16 --scale-factor=0.01 --format=native
+  --query-id=16 --scale-factor=0.01 --format=parquet
+  --query-id=16 --scale-factor=0.1 --format=native
+  --query-id=16 --scale-factor=0.1 --format=parquet
   --query-id=16 --scale-factor=1 --format=native
   --query-id=16 --scale-factor=1 --format=parquet
   --query-id=16 --scale-factor=10 --format=native
   --query-id=16 --scale-factor=10 --format=parquet
+  --query-id=17 --scale-factor=0.01 --format=native
+  --query-id=17 --scale-factor=0.01 --format=parquet
+  --query-id=17 --scale-factor=0.1 --format=native
+  --query-id=17 --scale-factor=0.1 --format=parquet
   --query-id=17 --scale-factor=1 --format=native
   --query-id=17 --scale-factor=1 --format=parquet
   --query-id=17 --scale-factor=10 --format=native
   --query-id=17 --scale-factor=10 --format=parquet
+  --query-id=18 --scale-factor=0.01 --format=native
+  --query-id=18 --scale-factor=0.01 --format=parquet
+  --query-id=18 --scale-factor=0.1 --format=native
+  --query-id=18 --scale-factor=0.1 --format=parquet
   --query-id=18 --scale-factor=1 --format=native
   --query-id=18 --scale-factor=1 --format=parquet
   --query-id=18 --scale-factor=10 --format=native
   --query-id=18 --scale-factor=10 --format=parquet
+  --query-id=19 --scale-factor=0.01 --format=native
+  --query-id=19 --scale-factor=0.01 --format=parquet
+  --query-id=19 --scale-factor=0.1 --format=native
+  --query-id=19 --scale-factor=0.1 --format=parquet
   --query-id=19 --scale-factor=1 --format=native
   --query-id=19 --scale-factor=1 --format=parquet
   --query-id=19 --scale-factor=10 --format=native
   --query-id=19 --scale-factor=10 --format=parquet
+  --query-id=20 --scale-factor=0.01 --format=native
+  --query-id=20 --scale-factor=0.01 --format=parquet
+  --query-id=20 --scale-factor=0.1 --format=native
+  --query-id=20 --scale-factor=0.1 --format=parquet
   --query-id=20 --scale-factor=1 --format=native
   --query-id=20 --scale-factor=1 --format=parquet
   --query-id=20 --scale-factor=10 --format=native
   --query-id=20 --scale-factor=10 --format=parquet
+  --query-id=21 --scale-factor=0.01 --format=native
+  --query-id=21 --scale-factor=0.01 --format=parquet
+  --query-id=21 --scale-factor=0.1 --format=native
+  --query-id=21 --scale-factor=0.1 --format=parquet
   --query-id=21 --scale-factor=1 --format=native
   --query-id=21 --scale-factor=1 --format=parquet
   --query-id=21 --scale-factor=10 --format=native
   --query-id=21 --scale-factor=10 --format=parquet
+  --query-id=22 --scale-factor=0.01 --format=native
+  --query-id=22 --scale-factor=0.01 --format=parquet
+  --query-id=22 --scale-factor=0.1 --format=native
+  --query-id=22 --scale-factor=0.1 --format=parquet
   --query-id=22 --scale-factor=1 --format=native
   --query-id=22 --scale-factor=1 --format=parquet
   --query-id=22 --scale-factor=10 --format=native
@@ -105,7 +193,7 @@ Usage: conbench tpch [OPTIONS]
 
 Options:
   --query-id [1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22]
-  --scale-factor [1|10]
+  --scale-factor [0.01|0.1|1|10]
   --format [native|parquet]
   --all BOOLEAN                   [default: false]
   --iterations INTEGER            [default: 1]
@@ -130,21 +218,21 @@ def assert_benchmark(result, name, language="Python"):
         "engine": "arrow",
         "memory_map": False,
         "query_id": "TPCH-01",
-        "scale_factor": 1,
+        "scale_factor": 0.01,
         "format": "native",
     }
     if language == "R":
         expected["language"] = "R"
     assert munged["tags"] == expected
     assert result["run_id"] == "some-run-id"
-    assert result["batch_id"] == "some-run-id-1n"
+    assert result["batch_id"] == "some-run-id-0.01n"
     _asserts.assert_info_and_context(munged, language=language)
 
 
 def test_benchmark_r():
     benchmark = tpch_benchmark.TpchBenchmark()
     run_id = "some-run-id"
-    [(result, output)] = benchmark.run(iterations=1, run_id=run_id)
+    [(result, output)] = benchmark.run(iterations=1, run_id=run_id, scale_factor=0.01)
     assert_benchmark(result, benchmark.name, language="R")
     assert _asserts.R_CLI in str(output)
 

--- a/benchmarks/tpch_benchmark.py
+++ b/benchmarks/tpch_benchmark.py
@@ -6,7 +6,7 @@ from benchmarks import _benchmark
 def get_valid_cases():
     result = [["query_id", "scale_factor", "format"]]
     for query_id in range(1, 23):
-        for scale_factor in [1, 10]:
+        for scale_factor in [0.01, 0.1, 1, 10]:
             for _format in ["native", "parquet"]:
                 result.append([query_id, scale_factor, _format])
     return result
@@ -31,7 +31,7 @@ class TpchBenchmark(_benchmark.BenchmarkR):
 
     def _set_defaults(self, options):
         options["query_id"] = int(options.get("query_id", 1))
-        options["scale_factor"] = int(options.get("scale_factor", 1))
+        options["scale_factor"] = float(options.get("scale_factor", 1))
         options["format"] = options.get("format", "native")
 
     def _manually_batch(self, options, case):


### PR DESCRIPTION
Closes #106; parallel to https://github.com/ursacomputing/arrowbench/pull/105. Adds the ability to version cases by overwriting a `version_cases()` method that takes in a case tuple and returns `None` (no versioning; continue current behavior) or an integer, which will be appended to `tags` as `case_version`.

Also adds a pile of type hints to `_benchmark.py` because I wrote them out before when trying to understand data flow.

Also changes the TPC-H benchmark to allow for smaller scale factors and uses them in tests so they don't take half an hour on CI.