### PR TITLE
Pass through case version tags from R json

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -192,7 +192,9 @@ class BenchmarkR(Benchmark):
     def r_benchmark(self, command, extra_tags, options, case=None):
         tags, info, context = self._get_tags_info_context(case, extra_tags)
         self._add_r_tags_info_context(tags, info, context)
-        data, iterations = [], options.get("iterations", 1)
+        data = []
+        case_version = None
+        iterations = options.get("iterations", 1)
 
         for _ in range(iterations):
             if options.get("drop_caches", False):
@@ -200,8 +202,13 @@ class BenchmarkR(Benchmark):
             try:
                 result, output = self._get_benchmark_result(command)
                 data.extend([row["real"] for row in result["result"]])
+                if not case_version and "case_version" in result["tags"]:
+                    case_version = result["tags"]["case_version"]
             except Exception as e:
                 return self._handle_error(e, self.name, tags, info, context, command)
+
+        if case_version:
+            tags["case_version"] = case_version
 
         return self.record(
             {"data": data, "unit": "s"},


### PR DESCRIPTION
Closes #107. When it exists, pulls the value for `case_version` out of the tags of the JSON generated by {arrowbench} when running R benchmarks, and appends it to the tags sent on to conbench.

Notably this PR does not replace all the Python-generated tags with the R-generated ones, because they do not correspond exactly, so doing so would break histories. There are reasons they differ, e.g. {arrowbench} does not also append `name` as a `tag` (maybe it should for history's sake? but it's duplicative); params vary in cases like `csv-read` where Python and R do not have the same params and functionality. Long-term, we'll need to fix the situation, but efforts now to align {benchmarks} and {arrowbench} will become historical artifacts as orchestration gets moved out of {benchmarks}, so I think it's more worthwhile now to figure out what we want our data to look like, and then break all our histories at that point. Open to other ideas!