### PR TITLE
File consistency

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -86,6 +86,7 @@ class Benchmark(conbench.runner.Benchmark):
                 context=context,
                 github=self.github_info,
                 options=options,
+                publish=os.environ.get("DRY_RUN") is None,
             )
         except Exception as e:
             benchmark, output = self._handle_error(e, self.name, tags, info, context)
@@ -116,6 +117,7 @@ class Benchmark(conbench.runner.Benchmark):
             github=self.github_info,
             options=options,
             output=output,
+            publish=os.environ.get("DRY_RUN") is None,
         )
         return benchmark, output
 

--- a/benchmarks/dataset_filter_benchmark.py
+++ b/benchmarks/dataset_filter_benchmark.py
@@ -16,7 +16,9 @@ class DatasetFilterBenchmark(_benchmark.Benchmark):
     def run(self, source, **kwargs):
         for source in self.get_sources(source):
             path = source.create_if_not_exists("parquet", "lz4")
-            dataset = pyarrow.dataset.dataset(path, format="parquet")
+            dataset = pyarrow.dataset.dataset(
+                path, schema=source.schema, format="parquet"
+            )
             f = self._get_benchmark_function(dataset)
             tags = self.get_tags(kwargs, source)
             yield self.benchmark(f, tags, kwargs)

--- a/benchmarks/file_benchmark.py
+++ b/benchmarks/file_benchmark.py
@@ -69,11 +69,13 @@ class FileReadBenchmark(FileBenchmark):
         path = source.create_if_not_exists(file_type, compression)
 
         if file_type == "parquet" and output_type == "table":
-            f = lambda: parquet.read_table(path, memory_map=False)
+            f = lambda: parquet.read_table(path, memory_map=False, schema=source.schema)
         elif file_type == "parquet" and output_type == "dataframe":
-            f = lambda: parquet.read_pandas(path, memory_map=False)
+            f = lambda: parquet.read_pandas(
+                path, memory_map=False, schema=source.schema
+            )
         elif file_type == "feather" and output_type == "table":
-            f = lambda: feather.read_table(path, memory_map=False)
+            f = lambda: feather.read_table(path, memory_map=False).cast(source.schema)
         elif file_type == "feather" and output_type == "dataframe":
             f = lambda: feather.read_feather(path, memory_map=False)
 

--- a/benchmarks/tests/_asserts.py
+++ b/benchmarks/tests/_asserts.py
@@ -91,9 +91,7 @@ LOAN_HOLDBACK_INDICATOR: string
 SERV_IND: string"""
 
 
-def assert_table_output(
-    source, output, nyc_ts=False, nyc_select=False, ts_precision="ns"
-):
+def assert_table_output(source, output, nyc_ts=False, nyc_select=False):
     if source.startswith("nyctaxi"):
         if nyc_ts:
             text = NYCTAXI_TABLE_TIMESTAMP
@@ -104,7 +102,6 @@ def assert_table_output(
     else:
         text = FANNIEMAE_TABLE
 
-    text = text.replace("[ns]", f"[{ts_precision}]")
     out = str(output)
 
     assert text in out

--- a/benchmarks/tests/conftest.py
+++ b/benchmarks/tests/conftest.py
@@ -1,6 +1,11 @@
+import os
+
 import pytest
 
 pytest.register_assert_rewrite("benchmarks.tests._asserts")
+
+# set to not try to send anything to conbench
+os.environ["DRY_RUN"] = "1"
 
 
 def pytest_addoption(parser):

--- a/benchmarks/tests/test_dataset_filter_benchmark.py
+++ b/benchmarks/tests/test_dataset_filter_benchmark.py
@@ -26,7 +26,7 @@ Options:
 def assert_run(run, index, benchmark, source):
     result, output = run[index]
     _asserts.assert_benchmark(result, source.name, benchmark.name)
-    _asserts.assert_table_output(source.name, output, ts_precision="us")
+    _asserts.assert_table_output(source.name, output)
 
 
 def test_dataset_filter():

--- a/benchmarks/tests/test_file_benchmark.py
+++ b/benchmarks/tests/test_file_benchmark.py
@@ -105,8 +105,7 @@ def assert_run_read(run, index, case, source):
     result, output = run[index]
     assert_benchmark(result, case, source.name, "read", "output_type")
     if "pyarrow.Table" in str(output):
-        ts_precision = "ns" if case[0] == "feather" else "us"
-        _asserts.assert_table_output(source.name, output, ts_precision=ts_precision)
+        _asserts.assert_table_output(source.name, output)
     else:
         _asserts.assert_dimensions_output(source.name, output)
 


### PR DESCRIPTION
A PR to clean up various issues, mostly with files, causing problems in buildkite builds and tests (especially when run more than once). Specifically:

- Removes file size validation. This was not used in benchmarks themselves, only when loading source data, so this should not affect benchmarks. If we're really worried about file integrity, let's test this some other way that causes fewer headaches.
- Changes cache format to parquet so we can specify more options when writing and reading
- Sets `coerce_timestamps="us"` when writing parquet to fix timestamp precision consistency issues
    - Reverts timestamp precision change in asserts because this fixes the issue globally
- Specifies schemas on read, because type inference fails when columns are all null (common in sample data subsets)
- Adds the `DRY_RUN` env var as in #115 because I'm sick of the mess it makes when trying to hit a conbench instance that doesn't exist when testing

Passes all tests (clear cache, then 2x) and then running [this set of benchmarks](https://github.com/ursacomputing/arrow-benchmarks-ci/blob/main/config.py#L73-L81) via `conbench` with `ALL` or equivalent for source.