### PR TITLE
Handle either legacy or Conbench-compliant JSON from R

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,10 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,13 +12,13 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout benchmarks
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Setup R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
       - name: Lint (black)
         uses: psf/black@stable
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,11 @@
 name: build
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Setup R
         uses: r-lib/actions/setup-r@v1
       - name: Lint (black)

--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -284,12 +284,13 @@ class BenchmarkR(Benchmark):
     def _get_benchmark_result(self, command: str) -> Tuple[Dict[str, Any], str]:
         shutil.rmtree("results", ignore_errors=True)
         output, error = self.conbench.execute_r_command(command, quiet=False)
-        try:
-            result_path = self._get_results_path()
-            with open(result_path) as json_file:
-                data = json.load(json_file)
-        except FileNotFoundError:
+
+        result_path = self._get_results_path()
+        if not result_path:
             raise Exception(error)
+        with open(result_path) as json_file:
+            data = json.load(json_file)
+
         return data, output
 
     def _get_results_path(self) -> str:

--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import conbench.runner
@@ -292,8 +293,10 @@ class BenchmarkR(Benchmark):
         return data, output
 
     def _get_results_path(self) -> str:
-        for file in os.listdir(f"results/{self.r_name}"):
-            return os.path.join(f"results/{self.r_name}", file)
+        # R benchmark name can match object name (`r_name`) or Python name (`.name`)
+        for path in [Path("results", self.r_name), Path("results", self.name)]:
+            for file in path.resolve().glob("*"):
+                return file
 
     def _add_r_tags_info_context(
         self, tags: Dict[str, Any], info: Dict[str, Any], context: Dict[str, Any]

--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -252,7 +252,12 @@ class BenchmarkR(Benchmark):
                 self.conbench.sync_and_drop_caches()
             try:
                 result, output = self._get_benchmark_result(command)
-                data.extend([row["real"] for row in result["result"]])
+                if "stats" in result:
+                    # new arrowbench output aligned with conbench
+                    data += result["stats"]["data"]
+                else:
+                    # legacy arrowbench output
+                    data.extend([row["real"] for row in result["result"]])
                 if not case_version and "case_version" in result["tags"]:
                     case_version = result["tags"]["case_version"]
             except Exception as e:

--- a/benchmarks/file_benchmark.py
+++ b/benchmarks/file_benchmark.py
@@ -40,7 +40,7 @@ class FileBenchmark(_benchmark.BenchmarkPythonR):
                     yield self.r_benchmark(command, tags, kwargs, case)
 
     def _get_r_command(self, source, case, options):
-        # changed param names to align with Python in version 0.1.1
+        # changed param names to align with Python in version 0.2.0
         is_legacy_str, _ = self.conbench.execute_r_command(
             'cat(packageVersion("arrowbench") <= "0.1.0")'
         )

--- a/benchmarks/file_benchmark.py
+++ b/benchmarks/file_benchmark.py
@@ -40,14 +40,26 @@ class FileBenchmark(_benchmark.BenchmarkPythonR):
                     yield self.r_benchmark(command, tags, kwargs, case)
 
     def _get_r_command(self, source, case, options):
+        # changed param names to align with Python in version 0.1.1
+        is_legacy_str, _ = self.conbench.execute_r_command(
+            'cat(packageVersion("arrowbench") <= "0.1.0")'
+        )
+        is_legacy = is_legacy_str == "TRUE"
+
         file_type, compression, _type = case
+        file_type_var = "file_type"
         _type = "arrow_table" if _type == "table" else "data_frame"
-        _name = "input" if self.r_name == "write_file" else "output"
+        _name = "type"
+
+        if is_legacy:
+            file_type_var = "format"
+            _name = "input" if self.r_name == "write_file" else "output"
+
         return (
             f"library(arrowbench); "
             f"run_one({self.r_name}, "
             f'source="{source.name}", '
-            f'format="{file_type}", '
+            f'{file_type_var}="{file_type}", '
             f'compression="{compression}", '
             f'{_name}="{_type}", '
             f"cpu_count={self.r_cpu_count(options)})"

--- a/benchmarks/file_benchmark.py
+++ b/benchmarks/file_benchmark.py
@@ -49,11 +49,11 @@ class FileBenchmark(_benchmark.BenchmarkPythonR):
         file_type, compression, _type = case
         file_type_var = "file_type"
         _type = "arrow_table" if _type == "table" else "data_frame"
-        _name = "type"
+        _name = "input_type" if self.r_name == "write_file" else "output_type"
 
         if is_legacy:
             file_type_var = "format"
-            _name = "input" if self.r_name == "write_file" else "output"
+            _name = _name.split("_")[0]
 
         return (
             f"library(arrowbench); "


### PR DESCRIPTION
Necessary to handle changes coming soon to arrowbench. This change will pull times out of `stats` (where Conbench wants them to be) if `stats` exists (which it will soon), otherwise `results` (the legacy key used by arrowbench). Technically `results` will still exist in `optional_benchmark_info.result` so we could use that, but it seems better to get it from where Conbench wants it to be.

Tested against my coming version of arrowbench (with `stats` populated), and works fine. Ultimately this code is temporary, though, as arrowbench will be able to handle its own running before too long.